### PR TITLE
Fix/gcc5.4 tuple init list

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ There's an excellent discussion of the Munkres Algorithm at [topcoder.com](https
 
 ### Requirements
 
- * A [C++17 compatible](https://en.cppreference.com/w/cpp/compiler_support) compiler
+ * A [C++14 or C++17 compatible](https://en.cppreference.com/w/cpp/compiler_support) compiler
  * [GNU Make](https://www.gnu.org/software/make/) (To build and run examples.)
- 
+
 ### Testcases
 
 Tested on Ubuntu 18.04, with [Clang 6.0](http://releases.llvm.org/6.0.1/tools/clang/docs/ReleaseNotes.html) and [gcc 7.3.0](https://www.gnu.org/software/gcc/gcc-7/). Should work without issue on [Visual Studio](https://visualstudio.microsoft.com/), or any other compiler with [C++17 support](https://en.cppreference.com/w/cpp/compiler_support).

--- a/munkres.hpp
+++ b/munkres.hpp
@@ -196,19 +196,19 @@ template<typename T> struct MunkresData
       if(find_uncovered_row_col(saved_row, saved_col))
          M(saved_row, saved_col) = PRIME;
       else
-         return {5, saved_row, saved_col}; // all zeros covered
+         return std::tuple<int, unsigned, unsigned>{5, saved_row, saved_col}; // all zeros covered
 
       // If there's a STAR in the PRIMEd row, then:
       for(auto c = 0u; c < side(); ++c) {
          if(M(saved_row, c) == STAR) {
             cover_row(saved_row);             // cover that row
             uncover_col(c);                   // uncover the column
-            return {3, saved_row, saved_col}; // and repeat this step
+            return std::tuple<int, unsigned, unsigned>{3, saved_row, saved_col}; // and repeat this step
          }
       }
 
       // There's no STAR in the PRIMEd row, onto "augmenting path"
-      return {4, saved_row, saved_col};
+      return std::tuple<int, unsigned, unsigned>{4, saved_row, saved_col};
    }
 
    // ------------------------------------------------------------------- Step 4

--- a/munkres.hpp
+++ b/munkres.hpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <limits>
 #include <vector>
+#include <algorithm>
 
 namespace detail
 {


### PR DESCRIPTION
Fix error converting to std::tuple from initializer list would use explicit constructor error in GCC5.4.